### PR TITLE
Google Ubuntu Stemcells use Ubuntu-specific packages

### DIFF
--- a/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
+++ b/bosh-stemcell/lib/bosh/stemcell/stage_collection.rb
@@ -142,7 +142,6 @@ module Bosh::Stemcell
 
     def google_stages
       [
-        :rsyslog_config,
         :system_network,
         :system_google_modules,
         :system_google_packages,

--- a/stemcell_builder/stages/rsyslog_config/assets/rsyslog_upstart.conf
+++ b/stemcell_builder/stages/rsyslog_config/assets/rsyslog_upstart.conf
@@ -11,6 +11,12 @@ stop on runlevel [06]
 expect fork
 respawn
 
+pre-start script
+	until mountpoint -q /var/log; do
+	  sleep .1
+	done
+end script
+
 script
     . /etc/default/rsyslog
     exec /usr/sbin/rsyslogd $RSYSLOGD_OPTIONS

--- a/stemcell_builder/stages/system_google_packages/config.sh
+++ b/stemcell_builder/stages/system_google_packages/config.sh
@@ -9,8 +9,11 @@ source $base_dir/lib/prelude_config.bash
 cd $assets_dir
 
 # Download google-image-packages
-wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-compute-engine-init-ubuntu-trusty_2.1.0-0.1474671297_amd64.deb
-echo "8081f1a3a92c7a64b762f8382dc42c952633cb08  google-compute-engine-init-ubuntu-trusty_2.1.0-0.1474671297_amd64.deb" | sha1sum -c -
+wget https://storage.googleapis.com/bosh-cpi-artifacts/google-compute-engine-init-trusty_2.1.0-0.1474913068_amd64.deb
+echo "229a1cd551b865cab199516e7572412fa4fde903  google-compute-engine-init-trusty_2.1.0-0.1474913068_amd64.deb" | sha1sum -c -
 
-wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-compute-engine-wheezy_2.1.3-0.1474395669_all.deb
-echo "820d7d06afd7a60d884fea1570a6e5ba108b967b  google-compute-engine-wheezy_2.1.3-0.1474395669_all.deb" | sha1sum -c -
+wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-compute-engine-trusty_2.2.3-0.1474912841_all.deb
+echo "0da71ccd637145f34ef4e97bcdc741d5b8177081  google-compute-engine-trusty_2.2.3-0.1474912841_all.deb" | sha1sum -c -
+
+wget https://storage.googleapis.com/bosh-stemcell-artifacts/google-config-trusty_2.0.0-0.1474912881_amd64.deb
+echo "d8cc6556a73e5766a032230b900f6a24e30e66df  google-config-trusty_2.0.0-0.1474912881_amd64.deb" | sha1sum -c -


### PR DESCRIPTION
- updated packages are ubuntu-specific, use upstart instead of System V init,
  cooperate with BOSH's customized rsyslog start behavior
- revert rsyslog to original behavior: waits until /var/log is mounted
- removed `rsyslog_config` stage, was performed earlier in os_image
  stages for both Ubuntu and CentOS.

fixes:

```
The following packages have unmet dependencies:
 google-compute-engine-init-ubuntu-trusty : Depends: google-compute-engine-ubuntu-trusty but it is not installable
                                            Depends: google-config-ubuntu-trusty but it is not installable
 google-compute-engine-wheezy : Depends: google-compute-engine-init-wheezy but it is not installable
E: Unmet dependencies. Try 'apt-get -f install' with no packages (or specify a solution).
```

[#130561911](https://www.pivotaltracker.com/story/show/130561911)
